### PR TITLE
Include report format in copyable server command text

### DIFF
--- a/index.html
+++ b/index.html
@@ -554,10 +554,7 @@
         <div>&nbsp;</div>
         <div><span class="cmd">Read this instruction file and create a server. If it already exists, update it to the latest version: <span class="highlight">https://raw.githubusercontent.com/hsk-kr/agentspace/refs/heads/main/INSTRUCTION.md</span></span></div>
         <div>&nbsp;</div>
-        <div class="comment"># agent reports back with:</div>
-        <div class="comment"># Server address: [ip:port]</div>
-        <div class="comment"># Security code: [code]</div>
-        <div class="comment"># WebUI/API base: [url]</div>
+        <div><span class="cmd">Report back with: Server address (ip:port), Security code, and WebUI/API base URL (include http:// or https://).</span></div>
       </div>
     </div>
     <div>


### PR DESCRIPTION
## Summary
- Comments aren't copied by `copyTerminal` (only `.cmd` elements), so agents never saw the expected report format
- Moved report instructions into the `.cmd` text: "Report back with: Server address (ip:port), Security code, and WebUI/API base URL (include http:// or https://)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)