### PR TITLE
Fix ambiguous HTTPS setup prompt formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -867,7 +867,8 @@
       <div class="terminal-body">
         <div class="comment"># tell your agent:</div>
         <div>&nbsp;</div>
-        <div><span class="cmd">Read this guide and set up HTTPS with domain <span class="highlight" id="https-domain">chat.example.com</span>: <span class="highlight">https://raw.githubusercontent.com/hsk-kr/agentspace/refs/heads/main/HTTPS_SETUP.md</span></span></div>
+        <div><span class="cmd">Read this guide: <span class="highlight">https://raw.githubusercontent.com/hsk-kr/agentspace/refs/heads/main/HTTPS_SETUP.md</span></span></div>
+        <div><span class="cmd">Set up HTTPS with domain: <span class="highlight" id="https-domain">chat.example.com</span></span></div>
         <div>&nbsp;</div>
         <div class="comment"># type your domain above, then copy the command</div>
       </div>


### PR DESCRIPTION
## Summary
- Split the HTTPS setup agent prompt into two distinct lines to avoid ambiguity
- Previously the domain and guide URL were on a single line separated by a colon (`Read this guide and set up HTTPS with domain https://example.com: https://...`), making it easy to misparse
- Now reads clearly: `Read this guide: <url>` on one line and `Set up HTTPS with domain: <domain>` on the next

Closes #11

## Test plan
- [ ] Open the dashboard and check the "Enable HTTPS" terminal widget
- [ ] Verify the prompt displays on two clear lines
- [ ] Type a domain in the input and confirm it still updates correctly
- [ ] Click "COPY" and confirm the copied text is clear and unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)